### PR TITLE
Fix ensure TL0 users also get an avatar flair at topics

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -52,7 +52,7 @@
     let username = helper.attrs.username
     let attrs = { model: { trust_level: trustLevel, username: username } };
     
-    if(trustLevel) {
+    if(trustLevel !== null && trustLevel !== undefined) {
       return helper.widget.attach("trust-level-avatar-flair", attrs);
     }
   });


### PR DESCRIPTION
This commit updates the avatar flair widget logic to ensure that users with a trust level of 0 (TL0) receive an avatar flair in topics. Previously, TL0 was considered falsy and thus ignored, preventing the flair from displaying for new users.