### PR TITLE
FIX: TL0 avatar flair doesn't appear in post

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -52,7 +52,7 @@
     let username = helper.attrs.username
     let attrs = { model: { trust_level: trustLevel, username: username } };
     
-    if(trustLevel) {
+    if(trustLevel >= 0) {
       return helper.widget.attach("trust-level-avatar-flair", attrs);
     }
   });


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/trust-level-avatar-flair/82656/109?u=arkshine

This PR fixes the avatar flair not appearing for TL0 users in posts.

